### PR TITLE
Correctly process entropy-tss binary passed as URL

### DIFF
--- a/recipes-core/entropy-tss/entropy-tss.bb
+++ b/recipes-core/entropy-tss/entropy-tss.bb
@@ -11,7 +11,6 @@ inherit update-rc.d
 
 python () {
     import bb
-    import bb.fetch2
     import os
     import shutil
 


### PR DESCRIPTION
This downloads, renames and set permissions on the binary when given as an environment variable.

It also removes the hard-coded binary, and makes it so the build fails if the environment variable with a URL for the binary is not set.
