### PR TITLE
Build entropy-tss using meta-rust-bin

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -7,6 +7,6 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "entropy"
 BBFILE_PATTERN_entropy = "^${LAYERDIR}/"
-BBFILE_PRIORITY_entropy = "5"
+BBFILE_PRIORITY_entropy = "30"
 LAYERVERSION_entropy = "4"
 LAYERSERIES_COMPAT_entropy = "scarthgap"

--- a/recipes-core/entropy-tss/entropy-tss.bb
+++ b/recipes-core/entropy-tss/entropy-tss.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Entropy TSS"
 HOMEPAGE = "https://github.com/entropyxyz/entropy-core"
-LICENSE = "MIT"
+LICENSE = "CLOSED"
 
 inherit cargo_bin
 
@@ -10,5 +10,4 @@ do_compile[network] = "1"
 SRC_URI = "git://github.com/entropyxyz/entropy-core.git;protocol=https;branch=master"
 SRCREV="1a04c4d37c8ce87ee3d737f75e24a84ed9729245"
 S = "${WORKDIR}/git"
-LIC_FILES_CHKSUM = "file://LICENSE-MIT;md5=935a9b2a57ae70704d8125b9c0e39059"
 EXTRA_CARGO_FLAGS = "-p entropy-tss"

--- a/recipes-core/entropy-tss/entropy-tss.bb
+++ b/recipes-core/entropy-tss/entropy-tss.bb
@@ -11,8 +11,8 @@ INITSCRIPT_PARAMS = "defaults 99"
 # Enable network for the compile task allowing cargo to download dependencies
 do_compile[network] = "1"
 
-SRC_URI = "git://github.com/entropyxyz/entropy-core.git;protocol=https;branch=master"
-SRCREV="1a04c4d37c8ce87ee3d737f75e24a84ed9729245"
+SRC_URI = "git://github.com/entropyxyz/entropy-core.git;protocol=https;branch=peg/fix-tss-production-mode"
+SRCREV="ecd7c932c8468939d866cf8887a5e4694ddcef51"
 S = "${WORKDIR}/git"
 EXTRA_CARGO_FLAGS = "-p entropy-tss"
 CARGO_FEATURES = "production"

--- a/recipes-core/entropy-tss/entropy-tss.bb
+++ b/recipes-core/entropy-tss/entropy-tss.bb
@@ -1,43 +1,13 @@
-DESCRIPTION = "Compile entropy-tss"
-LICENSE = "CLOSED"
-FILESEXTRAPATHS:prepend := "${THISDIR}:"
-S = "${WORKDIR}"
+SUMMARY = "GPIO Utilities"
+HOMEPAGE = "git://github.com/rust-embedded/gpio-utils"
+LICENSE = "MIT"
 
-INITSCRIPT_NAME = "entropy-tss"
-INITSCRIPT_PARAMS = "defaults 99"
-
-inherit cargo-bin update-rc.d
+inherit cargo_bin
 
 # Enable network for the compile task allowing cargo to download dependencies
 do_compile[network] = "1"
 
-SRC_URI = "git://github.com/entropy-xyz/entropy-core.git;branch=master"
-SRCREV = "1a04c4d37c8ce87ee3d737f75e24a84ed9729245"
-
-# SRC_URI += " file://init"
-
+SRC_URI = "git://github.com/rust-embedded/gpio-utils.git;protocol=https;branch=master"
+SRCREV="02b0658cd7e13e46f6b1a5de3fd9655711749759"
 S = "${WORKDIR}/git"
-
-RUST_TARGET="x86_64-unknown-linux-gnu"
-
-EXTRA_CARGO_FLAGS = "-p entropy-tss"
-CARGO_FEATURES = "production"
-
-do_install:append() {
-    # install -d ${D}${sysconfdir}/init.d
-    # cp init ${D}${sysconfdir}/init.d/${BINARY}
-    # chmod 755 ${D}${sysconfdir}/init.d/${BINARY}
-
-    # This is needed because ldd entropy-tss reveals that our binary expects
-    # to find ld-linux-x86-64.so.2 in /lib64
-    ln -rs ${D}/lib ${D}/lib64
-}
-
-FILES:${PN} += "${bindir} /lib64"
-
-# INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
-# INHIBIT_PACKAGE_STRIP = "1"
-
-DEPENDS += " openssl"
-DEPENDS += "rust-bin-${RUST_BIN_VERSION} cargo-bin-${RUST_BIN_VERSION}"
-RDEPENDS_${PN} += " libssl.so.3()(64bit)"
+LIC_FILES_CHKSUM = "file://LICENSE-MIT;md5=935a9b2a57ae70704d8125b9c0e39059"

--- a/recipes-core/entropy-tss/entropy-tss.bb
+++ b/recipes-core/entropy-tss/entropy-tss.bb
@@ -11,3 +11,6 @@ SRC_URI = "git://github.com/entropyxyz/entropy-core.git;protocol=https;branch=ma
 SRCREV="1a04c4d37c8ce87ee3d737f75e24a84ed9729245"
 S = "${WORKDIR}/git"
 EXTRA_CARGO_FLAGS = "-p entropy-tss"
+
+DEPENDS += " openssl"
+RDEPENDS_${PN} += " libssl.so.3()(64bit)"

--- a/recipes-core/entropy-tss/entropy-tss.bb
+++ b/recipes-core/entropy-tss/entropy-tss.bb
@@ -15,7 +15,7 @@ do_compile[network] = "1"
 SRC_URI = "git://github.com/entropy-xyz/entropy-core.git;branch=main"
 SRCREV = "1a04c4d37c8ce87ee3d737f75e24a84ed9729245"
 
-SRC_URI += "file://init"
+SRC_URI += " file://init"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-core/entropy-tss/entropy-tss.bb
+++ b/recipes-core/entropy-tss/entropy-tss.bb
@@ -1,5 +1,5 @@
-SUMMARY = "GPIO Utilities"
-HOMEPAGE = "git://github.com/rust-embedded/gpio-utils"
+SUMMARY = "Entropy TSS"
+HOMEPAGE = "https://github.com/entropyxyz/entropy-core"
 LICENSE = "MIT"
 
 inherit cargo_bin
@@ -7,7 +7,8 @@ inherit cargo_bin
 # Enable network for the compile task allowing cargo to download dependencies
 do_compile[network] = "1"
 
-SRC_URI = "git://github.com/rust-embedded/gpio-utils.git;protocol=https;branch=master"
-SRCREV="02b0658cd7e13e46f6b1a5de3fd9655711749759"
+SRC_URI = "git://github.com/entropyxyz/entropy-core.git;protocol=https;branch=master"
+SRCREV="1a04c4d37c8ce87ee3d737f75e24a84ed9729245"
 S = "${WORKDIR}/git"
 LIC_FILES_CHKSUM = "file://LICENSE-MIT;md5=935a9b2a57ae70704d8125b9c0e39059"
+EXTRA_CARGO_FLAGS = "-p entropy-tss"

--- a/recipes-core/entropy-tss/entropy-tss.bb
+++ b/recipes-core/entropy-tss/entropy-tss.bb
@@ -37,5 +37,5 @@ FILES:${PN} += "${bindir} /lib64"
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 INHIBIT_PACKAGE_STRIP = "1"
 
-DEPENDS += " openssl"
+DEPENDS += " openssl cargo-bin"
 RDEPENDS_${PN} += " libssl.so.3()(64bit)"

--- a/recipes-core/entropy-tss/entropy-tss.bb
+++ b/recipes-core/entropy-tss/entropy-tss.bb
@@ -1,8 +1,12 @@
 SUMMARY = "Entropy TSS"
 HOMEPAGE = "https://github.com/entropyxyz/entropy-core"
 LICENSE = "CLOSED"
+FILESEXTRAPATHS:prepend := "${THISDIR}:"
 
 inherit cargo_bin
+
+INITSCRIPT_NAME = "entropy-tss"
+INITSCRIPT_PARAMS = "defaults 99"
 
 # Enable network for the compile task allowing cargo to download dependencies
 do_compile[network] = "1"
@@ -11,6 +15,20 @@ SRC_URI = "git://github.com/entropyxyz/entropy-core.git;protocol=https;branch=ma
 SRCREV="1a04c4d37c8ce87ee3d737f75e24a84ed9729245"
 S = "${WORKDIR}/git"
 EXTRA_CARGO_FLAGS = "-p entropy-tss"
+CARGO_FEATURES = "production"
 
+SRC_URI += " file://init"
+
+do_install:append() {
+    install -d ${D}${sysconfdir}/init.d
+    cp init ${D}${sysconfdir}/init.d/${INITSCRIPT_NAME}
+    chmod 755 ${D}${sysconfdir}/init.d/${INITSCRIPT_NAME}
+
+    # This is needed because ldd entropy-tss reveals that our binary expects
+    # to find ld-linux-x86-64.so.2 in /lib64
+    ln -rs ${D}/lib ${D}/lib64
+}
+
+FILES:${PN} += " /lib64"
 DEPENDS += " openssl"
 RDEPENDS_${PN} += " libssl.so.3()(64bit)"

--- a/recipes-core/entropy-tss/entropy-tss.bb
+++ b/recipes-core/entropy-tss/entropy-tss.bb
@@ -19,6 +19,8 @@ SRC_URI += "file://init"
 
 S = "${WORKDIR}/git"
 
+RUST_TARGET="x86_64-unknown-linux-gnu"
+
 EXTRA_CARGO_FLAGS = "-p entropy-tss"
 CARGO_FEATURES = "production"
 
@@ -37,5 +39,6 @@ FILES:${PN} += "${bindir} /lib64"
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 INHIBIT_PACKAGE_STRIP = "1"
 
-DEPENDS += " openssl cargo-bin"
+DEPENDS += " openssl"
+DEPENDS += "rust-bin-${RUST_BIN_VERSION} cargo-bin-${RUST_BIN_VERSION}"
 RDEPENDS_${PN} += " libssl.so.3()(64bit)"

--- a/recipes-core/entropy-tss/entropy-tss.bb
+++ b/recipes-core/entropy-tss/entropy-tss.bb
@@ -15,7 +15,7 @@ do_compile[network] = "1"
 SRC_URI = "git://github.com/entropy-xyz/entropy-core.git;branch=main"
 SRCREV = "1a04c4d37c8ce87ee3d737f75e24a84ed9729245"
 
-SRC_URI += " file://init"
+# SRC_URI += " file://init"
 
 S = "${WORKDIR}/git"
 
@@ -25,9 +25,9 @@ EXTRA_CARGO_FLAGS = "-p entropy-tss"
 CARGO_FEATURES = "production"
 
 do_install:append() {
-    install -d ${D}${sysconfdir}/init.d
-    cp init ${D}${sysconfdir}/init.d/${BINARY}
-    chmod 755 ${D}${sysconfdir}/init.d/${BINARY}
+    # install -d ${D}${sysconfdir}/init.d
+    # cp init ${D}${sysconfdir}/init.d/${BINARY}
+    # chmod 755 ${D}${sysconfdir}/init.d/${BINARY}
 
     # This is needed because ldd entropy-tss reveals that our binary expects
     # to find ld-linux-x86-64.so.2 in /lib64

--- a/recipes-core/entropy-tss/entropy-tss.bb
+++ b/recipes-core/entropy-tss/entropy-tss.bb
@@ -1,10 +1,9 @@
 DESCRIPTION = "Compile entropy-tss"
 LICENSE = "CLOSED"
 FILESEXTRAPATHS:prepend := "${THISDIR}:"
-BINARY = "entropy-tss"
 S = "${WORKDIR}"
 
-INITSCRIPT_NAME = "${BINARY}"
+INITSCRIPT_NAME = "entropy-tss"
 INITSCRIPT_PARAMS = "defaults 99"
 
 inherit cargo-bin update-rc.d
@@ -12,7 +11,7 @@ inherit cargo-bin update-rc.d
 # Enable network for the compile task allowing cargo to download dependencies
 do_compile[network] = "1"
 
-SRC_URI = "git://github.com/entropy-xyz/entropy-core.git;branch=main"
+SRC_URI = "git://github.com/entropy-xyz/entropy-core.git;branch=master"
 SRCREV = "1a04c4d37c8ce87ee3d737f75e24a84ed9729245"
 
 # SRC_URI += " file://init"
@@ -36,8 +35,8 @@ do_install:append() {
 
 FILES:${PN} += "${bindir} /lib64"
 
-INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
-INHIBIT_PACKAGE_STRIP = "1"
+# INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+# INHIBIT_PACKAGE_STRIP = "1"
 
 DEPENDS += " openssl"
 DEPENDS += "rust-bin-${RUST_BIN_VERSION} cargo-bin-${RUST_BIN_VERSION}"

--- a/recipes-core/entropy-tss/entropy-tss.bb
+++ b/recipes-core/entropy-tss/entropy-tss.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/entropyxyz/entropy-core"
 LICENSE = "CLOSED"
 FILESEXTRAPATHS:prepend := "${THISDIR}:"
 
-inherit cargo_bin
+inherit cargo_bin update-rc.d
 
 INITSCRIPT_NAME = "entropy-tss"
 INITSCRIPT_PARAMS = "defaults 99"
@@ -21,7 +21,7 @@ SRC_URI += " file://init"
 
 do_install:append() {
     install -d ${D}${sysconfdir}/init.d
-    cp init ${D}${sysconfdir}/init.d/${INITSCRIPT_NAME}
+    cp ${THISDIR}/init ${D}${sysconfdir}/init.d/${INITSCRIPT_NAME}
     chmod 755 ${D}${sysconfdir}/init.d/${INITSCRIPT_NAME}
 
     # This is needed because ldd entropy-tss reveals that our binary expects


### PR DESCRIPTION
This compiles entropy-tss from source using the [meta-rust-bin](https://github.com/rust-embedded/meta-rust-bin) layer.