### PR TITLE
Get chain endpoint from GCP metadata

### DIFF
--- a/recipes-core/entropy-tss/init
+++ b/recipes-core/entropy-tss/init
@@ -14,14 +14,34 @@ NAME=entropy_tss_vc
 DESC="Entropy Threshold Signature Server"
 PIDFILE=/var/run/entropy_tss_vc.pid
 
+METADATA_KEY="chain-endpoint"
+METADATA_URL="http://metadata.google.internal/computeMetadata/v1/instance/attributes"
+
+# For GCP, get chain endpoint from metadata
+get_config_from_metadata() {
+    if [ -n "$CHAIN_ENDPOINT" ]; then
+        echo "[*] CHAIN_ENDPOINT is already set: $CHAIN_ENDPOINT"
+    else
+        echo "[*] CHAIN_ENDPOINT not set, attempting to fetch from metadata..."
+
+        if ping -c 1 metadata.google.internal >/dev/null 2>&1; then
+            CHAIN_ENDPOINT=$(wget --header="Metadata-Flavor: Google" -qO - "${METADATA_URL}/${METADATA_KEY}")
+        else
+            echo "[!] Metadata server not reachable."
+        fi
+    fi
+}
+
 
 start() {
         echo -n "Starting $DESC: "
         mount -o remount,size=90% /var/volatile
         # This is a mock placeholder for the persistent fs until https://github.com/entropyxyz/meta-entropy-tss/pull/5 is merged
         mkdir -p /persist
+        get_config_from_metadata
         start-stop-daemon -S -p $PIDFILE -N -10 -b -a /bin/sh -- -c "exec ${DAEMON} \
                 --threshold-url 0.0.0.0:3001 \
+                --chain-endpoint $CHAIN_ENDPOINT \
                 2>&1 | tee /tmp/entropy-tss-logs"
         echo "$NAME."
 }

--- a/recipes-core/entropy-tss/init
+++ b/recipes-core/entropy-tss/init
@@ -20,15 +20,11 @@ METADATA_URL="http://metadata.google.internal/computeMetadata/v1/instance/attrib
 # For GCP, get chain endpoint from metadata
 get_config_from_metadata() {
     if [ -n "$CHAIN_ENDPOINT" ]; then
-        echo "[*] CHAIN_ENDPOINT is already set: $CHAIN_ENDPOINT"
+        echo "CHAIN_ENDPOINT is already set: $CHAIN_ENDPOINT"
     else
-        echo "[*] CHAIN_ENDPOINT not set, attempting to fetch from metadata..."
-
-        if ping -c 1 metadata.google.internal >/dev/null 2>&1; then
-            CHAIN_ENDPOINT=$(wget --header="Metadata-Flavor: Google" -qO - "${METADATA_URL}/${METADATA_KEY}")
-        else
-            echo "[!] Metadata server not reachable."
-        fi
+        echo "CHAIN_ENDPOINT not set, attempting to fetch from metadata..."
+        CHAIN_ENDPOINT=$(wget --header="Metadata-Flavor: Google" --tries=35 --waitretry=30 -qO - "${METADATA_URL}/${METADATA_KEY}") \
+           || echo "Failed to set chain endpoint"
     fi
 }
 

--- a/recipes-core/entropy-tss/init
+++ b/recipes-core/entropy-tss/init
@@ -16,6 +16,7 @@ PIDFILE=/var/run/entropy_tss_vc.pid
 
 METADATA_KEY="chain-endpoint"
 METADATA_URL="http://metadata.google.internal/computeMetadata/v1/instance/attributes"
+RETRIES=35
 
 # For GCP, get chain endpoint from metadata
 get_config_from_metadata() {
@@ -23,8 +24,11 @@ get_config_from_metadata() {
         echo "CHAIN_ENDPOINT is already set: $CHAIN_ENDPOINT"
     else
         echo "CHAIN_ENDPOINT not set, attempting to fetch from metadata..."
-        CHAIN_ENDPOINT=$(wget --header="Metadata-Flavor: Google" --tries=35 --waitretry=30 -qO - "${METADATA_URL}/${METADATA_KEY}") \
-           || echo "Failed to set chain endpoint"
+        for i in $(seq 1 $RETRIES); do
+            CHAIN_ENDPOINT=$(wget --header="Metadata-Flavor: Google" -qO - "${METADATA_URL}/${METADATA_KEY}") && break
+            echo "Retry $i failed"
+            sleep 5
+        done
     fi
 }
 


### PR DESCRIPTION
For context see https://github.com/entropyxyz/devops-infrastructure/issues/113

This uses cloud metadata to get the chain-endpoint configuration from Google Compute Engine during the init script which runs entropy-tss. 

That is it assumes the metadata has been set using `--metadata chain-endpoint=ws://my-chain-endpoint:9944` (or terraform equivalent) when starting the Google VM instance.

This is really just a PoC - ideally we would have some retry / backoff logic and even better, support other platforms (eg: bare metal / microsoft azure).

Note: This is only needed for entropy-tss.  The API key service and other 'trees' do not need an instance-specific chain endpoint.